### PR TITLE
Add source map building in webpack and expose them to chrome

### DIFF
--- a/ui/browser-extension/manifest.json
+++ b/ui/browser-extension/manifest.json
@@ -22,5 +22,11 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     }
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["dist/src/*.js.map"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/ui/browser-extension/webpack.config.js
+++ b/ui/browser-extension/webpack.config.js
@@ -24,4 +24,5 @@ module.exports = {
       },
     ],
   },
+  devtool: 'source-map',
 };


### PR DESCRIPTION
Add source maps to the build folder to make debugging easier. Chrome dev tools looks like this now:

![Screenshot 2024-11-07 at 11 21 52 AM](https://github.com/user-attachments/assets/39433f3d-4174-4621-b06b-84461db1c008)
