### PR TITLE
Enable toggle transform button in the popup

### DIFF
--- a/ui/browser-extension/src/api/backendApi.ts
+++ b/ui/browser-extension/src/api/backendApi.ts
@@ -1,0 +1,48 @@
+// TODO: make this dynamic based on which environment we're in, for now it's
+// hardcoded to only work locally
+import { CONFIG } from '../../configs/config.local';
+import { Article } from '../models/Article';
+import { TransformedArticle } from '../models/TransformedArticle';
+import { getBackendUrlFromEnvironmentAndVersion } from '../utils/constants';
+
+export async function getTransformation(
+  article: Article,
+): Promise<TransformedArticle> {
+  try {
+    const result = await makeRequest<TransformedArticle>(
+      'POST',
+      '/headline',
+      article,
+    );
+
+    console.log(`background::sendResponse: ${JSON.stringify(result, null, 2)}`);
+
+    return result;
+  } catch (error) {
+    console.error('Error fetching transformed headline:', error);
+    throw error;
+  }
+}
+
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+function makeRequest<T>(
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const baseUrl = getBackendUrlFromEnvironmentAndVersion(
+    CONFIG.BACKEND_URL,
+    CONFIG.API_VERSION,
+  );
+  const url = `${baseUrl}${path}`;
+  return fetch(url, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+    .then((response) => response.json())
+    .then((data: T) => data);
+}

--- a/ui/browser-extension/src/api/dummyApi.ts
+++ b/ui/browser-extension/src/api/dummyApi.ts
@@ -1,0 +1,8 @@
+import { Article } from '../models/Article';
+import { TransformedArticle } from '../models/TransformedArticle';
+
+export async function dummyGetTransformation(
+  article: Article,
+): Promise<TransformedArticle> {
+  return Promise.resolve({ transformedText: article.headline.toUpperCase() });
+}

--- a/ui/browser-extension/src/contentScript.ts
+++ b/ui/browser-extension/src/contentScript.ts
@@ -1,64 +1,53 @@
+import { dummyGetTransformation } from './api/dummyApi';
+import { Article } from './models/Article';
+import { MessagePayload } from './models/MessagePayload';
+import { TransformedArticle } from './models/TransformedArticle';
+import ArticleStateManager from './utils/ArticleStateManager';
 import { TrustAssemblyMessage } from './utils/messagePassing';
 
 console.log('Trust Assembly Headline Transformer content script loaded.');
 
-interface TransformResponse {
-  transformedText: string;
+function findHeadlineElement() {
+  const selectors = [
+    'h1.main-headline',
+    'h1.article-title',
+    'h1.headline',
+    'h1.detailHeadline',
+    'h1[class*="headline"]', // Catch-all selector for any class containing the text "headline"
+  ];
+  console.log(
+    `Searching for headline element using these selectors: ${selectors.join(', ')}`,
+  );
+
+  for (const selector of selectors) {
+    const element = document.querySelector<HTMLElement>(selector);
+    if (element) {
+      console.log('Found headline element:', element);
+
+      return element;
+    }
+  }
+
+  console.log('Headline element not found on this page.');
 }
 
-// Function to replace the headline text
-const replaceHeadline = (
-  element: HTMLElement,
-  transformedText: string,
-): void => {
-  console.log('Replacing headline text: ', transformedText);
-  const originalText = element.textContent || '';
-  element.setAttribute('data-original-text', originalText);
-
-  // Replace the text content with the transformed text
-  element.textContent = transformedText;
-
-  console.log(`element.style.color: ${element.style.color}`);
-  console.log(`element.style.fontStyle: ${element.style.fontStyle}`);
-  // Optionally, add styling to make it distinguishable
-  element.setAttribute('data-original-color', element.style.color);
-  element.style.color = 'blue';
-  element.setAttribute('data-original-fontStyle', element.style.fontStyle);
-  element.style.fontStyle = 'italic';
-
-  // Add an event listener to toggle back to the original text
-  element.addEventListener('click', () => {
-    const currentText = element.textContent;
-    const storedOriginalText = element.getAttribute('data-original-text');
-    if (currentText === transformedText && storedOriginalText) {
-      element.textContent = storedOriginalText;
-      element.style.color = element.getAttribute('data-original-color') || '';
-      element.style.fontStyle =
-        element.getAttribute('data-original-fontStyle') || '';
-    } else {
-      element.textContent = transformedText;
-      element.style.color = 'blue';
-      element.style.fontStyle = 'italic';
-    }
-  });
-};
-
-// Function to request the transformed headline
 const requestTransformedHeadline = async (
-  originalText: string,
-): Promise<TransformResponse> => {
-  return new Promise((resolve) => {
-    resolve({ transformedText: originalText.toUpperCase() });
-  });
+  article: Article,
+): Promise<TransformedArticle> => {
+  // just use the dummy API for now
+  return await dummyGetTransformation(article);
 
   // TODO: uncomment this code below so that we actually communite with the backend
   // rather than just returning the original text uppercase. Right now @melvillian
   // commented this out to make the PR easier to work with; the plan is to
   // add backend communication to the extension and then uncomment this code.
 
-  // const response = await chrome.runtime.sendMessage({
+  // const response = await chrome.runtime.sendMessage<
+  //   MessagePayload,
+  //   TransformedArticle | undefined
+  // >({
   //   action: TrustAssemblyMessage.FETCH_TRANSFORMED_HEADLINE,
-  //   originalText,
+  //   article,
   // });
   // console.log('chrome.runtime.sendMessage');
   // console.log(`response: ${response}`);
@@ -73,47 +62,28 @@ const requestTransformedHeadline = async (
   // }
 };
 
-const findHeadlineElement = (): HTMLElement | null => {
-  const selectors = [
-    'h1.main-headline',
-    'h1.article-title',
-    'h1.headline',
-    'h1.detailHeadline',
-    'h1[class*="headline"]', // Catch-all selector for any class containing the text "headline"
-  ];
-  console.log(
-    `Searching for headline element using these selectors: ${selectors.join(', ')}`,
+const stateManager = new ArticleStateManager(requestTransformedHeadline);
+
+(async function () {
+  const elementToModify = findHeadlineElement();
+  if (!elementToModify) return;
+
+  await stateManager.setElement(elementToModify);
+
+  elementToModify.addEventListener('click', () =>
+    stateManager.toggleModification(),
   );
 
-  for (const selector of selectors) {
-    const element = document.querySelector(selector);
-    if (element) {
-      return element as HTMLElement;
-    }
-  }
-  return null;
-};
+  chrome.runtime.onMessage.addListener(
+    async (message: MessagePayload): Promise<boolean | undefined> => {
+      console.log('Got message:', message);
 
-// Main function to execute the transformation
-async function transformHeadline(): Promise<void> {
-  console.log('Starting headline transformation...');
-  const headlineElement = findHeadlineElement();
+      if (message.action === TrustAssemblyMessage.TOGGLE_MODIFICATION) {
+        stateManager.toggleModification();
+        return false;
+      }
+    },
+  );
 
-  if (headlineElement) {
-    console.log('Found headline element:', headlineElement);
-    const originalText = headlineElement.textContent || '';
-
-    try {
-      const response = await requestTransformedHeadline(originalText);
-      console.log('Received requestTransformedHeadline response:', response);
-      replaceHeadline(headlineElement, response.transformedText);
-    } catch (error) {
-      console.error('Error transforming headline:', error);
-    }
-  } else {
-    console.log('Headline element not found on this page.');
-  }
-}
-
-// Execute the transformation when the content script is loaded
-transformHeadline();
+  stateManager.toggleModification();
+})();

--- a/ui/browser-extension/src/models/Article.ts
+++ b/ui/browser-extension/src/models/Article.ts
@@ -1,0 +1,3 @@
+export type Article = {
+  headline: string;
+};

--- a/ui/browser-extension/src/models/MessagePayload.ts
+++ b/ui/browser-extension/src/models/MessagePayload.ts
@@ -1,0 +1,11 @@
+import { TrustAssemblyMessage } from '../utils/messagePassing';
+import { Article } from './Article';
+
+export type MessagePayload =
+  | {
+      action: TrustAssemblyMessage.TOGGLE_MODIFICATION;
+    }
+  | {
+      action: TrustAssemblyMessage.FETCH_TRANSFORMED_HEADLINE;
+      article: Article;
+    };

--- a/ui/browser-extension/src/models/TransformedArticle.ts
+++ b/ui/browser-extension/src/models/TransformedArticle.ts
@@ -1,0 +1,4 @@
+// this should probably just be an Article
+export type TransformedArticle = {
+  transformedText: string;
+};

--- a/ui/browser-extension/src/popup.ts
+++ b/ui/browser-extension/src/popup.ts
@@ -1,0 +1,14 @@
+import { TrustAssemblyMessage } from './utils/messagePassing';
+
+const transformButton = document.getElementById('toggle-transform');
+transformButton?.addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+  if (tab?.id) {
+    chrome.tabs.sendMessage(tab.id, {
+      action: TrustAssemblyMessage.TOGGLE_MODIFICATION,
+    });
+  }
+});

--- a/ui/browser-extension/src/utils/ArticleStateManager.ts
+++ b/ui/browser-extension/src/utils/ArticleStateManager.ts
@@ -1,0 +1,82 @@
+import { Article } from '../models/Article';
+import { TransformedArticle } from '../models/TransformedArticle';
+
+export type ArticleElement = {
+  style: {
+    color: string;
+    fontStyle: string;
+  };
+  article: Article;
+};
+
+const MODIFIED_STYLE = {
+  color: 'blue',
+  fontStyle: 'italic',
+} as const;
+
+/**
+ * Class to manage the state of the article transformation.
+ * Currently only supports toggling headline with the default style
+ */
+export default class ArticleStateManager {
+  private toggleState = false;
+  private element: HTMLElement | null = null;
+  private originalProps: ArticleElement | null = null;
+  private modifiedProps: ArticleElement | null = null;
+
+  constructor(
+    private fetchModification: (
+      article: Article,
+    ) => Promise<TransformedArticle>,
+  ) {}
+
+  public async setElement(element: HTMLElement): Promise<void> {
+    console.log('setting element:', element);
+
+    this.element = element;
+    this.originalProps = {
+      style: {
+        color: element.style.color,
+        fontStyle: element.style.fontStyle,
+      },
+      article: {
+        headline: element.textContent || '',
+      },
+    };
+
+    const modifiedArticle = await this.fetchModification(
+      this.originalProps.article,
+    );
+    this.modifiedProps = {
+      style: MODIFIED_STYLE,
+      article: {
+        headline: modifiedArticle.transformedText,
+      },
+    };
+  }
+
+  public toggleModification(): void {
+    if (!this.element || !this.originalProps) {
+      console.warn('No element to modify');
+      return;
+    }
+    if (!this.modifiedProps) {
+      console.warn('No modified headline to apply');
+      return;
+    }
+
+    this.toggleState = !this.toggleState;
+    const {
+      style: { color, fontStyle },
+      article: { headline },
+    } = this.toggleState ? this.modifiedProps : this.originalProps;
+
+    console.log(`element.style.color: ${color}`);
+    console.log(`element.style.fontStyle: ${fontStyle}`);
+    console.log(`element.textContent: ${headline}`);
+
+    this.element.style.color = color;
+    this.element.style.fontStyle = fontStyle;
+    this.element.textContent = headline;
+  }
+}

--- a/ui/browser-extension/src/utils/messagePassing.ts
+++ b/ui/browser-extension/src/utils/messagePassing.ts
@@ -1,4 +1,5 @@
 export enum TrustAssemblyMessage {
   FETCH_TRANSFORMED_HEADLINE = 'fetchTransformedHeadline',
+  TOGGLE_MODIFICATION = 'toggleModification',
   // Add more message types as needed
 }

--- a/ui/browser-extension/webpack.config.js
+++ b/ui/browser-extension/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: {
     contentScript: './src/contentScript.ts',
     background: './src/background.ts',
+    popup: './src/popup.ts',
     // Add other entry points if needed
   },
   output: {


### PR DESCRIPTION
- Refactor api call to break out to its own module
- Create dummy api client
- Add popup.ts and build with webpack
- Define models for request, response and messages
- Create state management class to save styling information and toggle state in memory, not on the DOM

This change kind of spiraled and I ended up re-writing most of the app. I can rework this to be a bit more granular if needed

Demo:

https://github.com/user-attachments/assets/e56c2203-90c5-4e54-a210-2fbb11508251

